### PR TITLE
Wordpress 4.7.3

### DIFF
--- a/Wordpress/Dockerfile
+++ b/Wordpress/Dockerfile
@@ -17,8 +17,12 @@ ENV HTTPD_SOURCE "/usr/src/httpd"
 ENV HTTPD_HOME "/usr/local/httpd"
 ENV HTTPD_CONF_DIR "$HTTPD_HOME/conf"
 ENV HTTPD_CONF_FILE "$HTTPD_CONF_DIR/httpd.conf"
-ENV HTTPD_LOG_DIR="/var/log/httpd"
+ENV HTTPD_LOG_DIR "/home/LogFiles/httpd"
 ENV PATH "$HTTPD_HOME/bin":$PATH
+
+# mariadb
+ENV MARIADB_DATA_DIR "/home/data/mysql"
+ENV MARIADB_LOG_DIR "/home/LogFiles/mysql"
 
 # php
 ENV PHP_VERSION "7.1.2"
@@ -30,11 +34,6 @@ ENV PHP_CONF_DIR "$PHP_HOME/etc"
 ENV PHP_CONF_DIR_SCAN "$PHP_CONF_DIR/conf.d"
 ENV PATH "$PHP_HOME/bin":$PATH
 
-# mariadb
-ENV MARIADB_DATA_DIR="/var/lib/mysql"
-ENV MARIADB_LOG_DIR="/var/log/mysql"
-ENV MARIADB_DATA_DIR_TEMP="/tmp/mariadb"
-
 # redis
 ENV REDIS_VERSION "3.2.8"
 ENV REDIS_DOWNLOAD_URL "http://download.redis.io/releases/redis-$REDIS_VERSION.tar.gz"
@@ -43,38 +42,39 @@ ENV REDIS_SOURCE "/usr/src/redis"
 ENV REDIS_HOME "/usr/local/redis"
 ENV PATH "$REDIS_HOME/bin":$PATH
 
-# wordpress
-ENV WORDPRESS_VERSION "4.7.2"
-ENV WORDPRESS_DOWNLOAD_URL "https://wordpress.org/wordpress-$WORDPRESS_VERSION.tar.gz"
-ENV WORDPRESS_SHA1 "7b687f1af589c337124e6247229af209ec1d52c3"
-ENV WORDPRESS_SOURCE "/usr/src/wordpress"
-ENV WORDPRESS_HOME "/var/www/wordpress"
-
 # phpMyAdmin
 ENV PHPMYADMIN_VERSION "4.6.6"
 ENV PHPMYADMIN_DOWNLOAD_URL "https://files.phpmyadmin.net/phpMyAdmin/$PHPMYADMIN_VERSION/phpMyAdmin-$PHPMYADMIN_VERSION-all-languages.tar.gz"
 ENV PHPMYADMIN_SHA256 "54086600558613b31c4daddf4ae58fbc1c252a2b8e3e6fae12f851f78677d72e"
 ENV PHPMYADMIN_SOURCE "/usr/src/phpmyadmin"
-ENV PHPMYADMIN_HOME "/var/www/phpmyadmin"
+ENV PHPMYADMIN_HOME "/home/phpmyadmin"
 
+# wordpress
+ENV WORDPRESS_VERSION "4.7.3"
+ENV WORDPRESS_DOWNLOAD_URL "https://wordpress.org/wordpress-$WORDPRESS_VERSION.tar.gz"
+ENV WORDPRESS_SHA1 "35adcd8162eae00d5bc37f35344fdc06b22ffc98"
+ENV WORDPRESS_SOURCE "/usr/src/wordpress"
+ENV WORDPRESS_HOME "/home/site/wwwroot"
+
+#
 ENV DOCKER_BUILD_HOME "/dockerbuild"
 
 
 # ====================
 # Download and Install
-# 1. essential tools
+# 1. tools
 # 2. apache httpd
-# 3. php
-# 4. mariadb
+# 3. mariadb
+# 4. php
 # 5. redis
-# 6. wordpress
-# 7. phpmyadmin
+# 6. phpmyadmin
+# 7. wordpress
 # ====================
 
 WORKDIR $DOCKER_BUILD_HOME
 RUN set -ex \
 	# ------------------
-	# 1. essential tools
+	# 1. tools
 	# ------------------
 	&& tools=" \
 		g++ \
@@ -122,6 +122,7 @@ RUN set -ex \
 		--enable-ssl \
 	&& make -j "$(nproc)" \
 	&& make install \
+	&& make clean \
 	## clean up
 	&& rm -rf $HTTPD_SOURCE \
 		$HTTPD_HOME/man \
@@ -129,8 +130,15 @@ RUN set -ex \
 	&& rm $DOCKER_BUILD_HOME/httpd.tar.gz \
 	&& apt-get purge -y -V -o APT::AutoRemove::RecommendsImportant=false --auto-remove $httpdBuildtimeDeps \
 
+	# ----------
+	# 3. mariadb
+	# ----------
+	&& apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server -y -V --no-install-recommends \
+	&& rm -r /var/lib/apt/lists/* \
+
 	# ------
-	# 3. php
+	# 4. php
 	# ------
 	### see http://php.net/manual/en/install.unix.apache2.php
 	### see http://linuxfromscratch.org/blfs/view/svn/general/php.html
@@ -139,12 +147,12 @@ RUN set -ex \
 	## buildtime deps
 	### libbz2-dev >> --with-bz2 >> [phpmyadmin] Bzip2 compression and decompression requires functions (bzopen, bzcompress) which are unavailable on this system.
 	### libgmp-dev >> --with-gmp
-        ### libicu-dev >> --enable-intl
+	### libicu-dev >> --enable-intl
 	### libldap2-dev >> --with-ldap
 	&& phpBuildtimeDeps="\
 		libbz2-dev \
 		libgmp-dev \
-                libicu-dev \
+		libicu-dev \
 		libldap2-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -156,7 +164,7 @@ RUN set -ex \
 	&& phpRuntimeDeps=" \
 		libcurl4-openssl-dev \
 		libjpeg-dev \
-                libpng12-dev \
+		libpng12-dev \
 		libxml2 \
 	" \
 	&& apt-get update \
@@ -193,23 +201,17 @@ RUN set -ex \
 		--with-gmp \
 		--with-ldap \
 		### see http://php.net/manual/en/mysqlnd.overview.php
-                ### see http://php.net/manual/en/mysqlinfo.api.choosing.php
+		### see http://php.net/manual/en/mysqlinfo.api.choosing.php
 		--with-mysqli=mysqlnd \
 		--with-openssl \
 	&& make -j "$(nproc)" \
-	&& make install \	
+	&& make install \
+	&& make clean \
 	## clean up
 	&& rm -rf $PHP_SOURCE \
 	&& rm -rf $PHP_HOME/php/man \
 	&& rm $DOCKER_BUILD_HOME/php.tar.gz \
 	&& apt-get purge -y -V -o APT::AutoRemove::RecommendsImportant=false --auto-remove $phpBuildtimeDeps \
-
-	# ----------
-	# 4. mariadb
-	# ----------
-	&& apt-get update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get install mariadb-server -y -V --no-install-recommends \
-	&& rm -r /var/lib/apt/lists/* \
 
 	# --------
 	# 5. redis
@@ -224,33 +226,29 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make PREFIX=$REDIS_HOME install \
 	&& rm -rf $REDIS_SOURCE \
-	&& rm $DOCKER_BUILD_HOME/redis.tar.gz \
-
-	# ------------	
-	# 6. wordpress
-	# ------------
-	&& mkdir -p $WORDPRESS_SOURCE \
-	&& cd $DOCKER_BUILD_HOME \
-	&& wget -O wordpress.tar.gz "$WORDPRESS_DOWNLOAD_URL" --no-check-certificate \
-	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
-	&& tar -xf wordpress.tar.gz -C $WORDPRESS_SOURCE --strip-components=1 \
-	&& rm $DOCKER_BUILD_HOME/wordpress.tar.gz \
+	E&& rm $DOCKER_BUILD_HOME/redis.tar.gz \
 
 	# -------------
-	# 7. phpmyadmin
+	# 6. phpmyadmin
 	# -------------
 	&& mkdir -p $PHPMYADMIN_SOURCE \
-	&& cd $DOCKER_BUILD_HOME \
+	&& cd $PHPMYADMIN_SOURCE \
 	&& wget -O phpmyadmin.tar.gz "$PHPMYADMIN_DOWNLOAD_URL" --no-check-certificate \
 	&& echo "$PHPMYADMIN_SHA256 *phpmyadmin.tar.gz" | sha256sum -c - \
-	&& tar -xf phpmyadmin.tar.gz -C $PHPMYADMIN_SOURCE --strip-components=1 \
-	&& rm $DOCKER_BUILD_HOME/phpmyadmin.tar.gz \
+
+	# ------------	
+	# 7. wordpress
+	# ------------
+	&& mkdir -p $WORDPRESS_SOURCE \
+	&& cd $WORDPRESS_SOURCE \
+	&& wget -O wordpress.tar.gz "$WORDPRESS_DOWNLOAD_URL" --no-check-certificate \
+	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
 
 	# ----------
-	# . clean up
+	# ~. clean up
 	# ----------
 	&& apt-get purge -y -V -o APT::AutoRemove::RecommendsImportant=false --auto-remove $tools \
-	&& apt-get autoremove -y	
+	&& apt-get autoremove -y
 
 
 # =========
@@ -263,61 +261,34 @@ COPY httpd-modules.conf $HTTPD_CONF_DIR/
 COPY httpd-php.conf $HTTPD_CONF_DIR/
 COPY httpd-wordpress.conf $HTTPD_CONF_DIR/
 COPY httpd-phpmyadmin.conf $HTTPD_CONF_DIR/
-
 # php confs
-COPY php-log.ini $PHP_CONF_DIR_SCAN/
+COPY php.ini $PHP_CONF_DIR/
 COPY php-opcache.ini $PHP_CONF_DIR_SCAN/
-
 # wordpress conf
 COPY wp-config.php.microsoft $WORDPRESS_SOURCE/
-
 # phpmyadmin conf
-COPY phpmyadmin-config.inc.php $PHPMYADMIN_SOURCE/config.inc.php
+COPY phpmyadmin-config.inc.php $PHPMYADMIN_SOURCE/
 
 RUN set -ex \
 	## include php.conf
 	&& echo 'Include conf/httpd-php.conf' >> $HTTPD_CONF_FILE \
-	## include wordpress.conf
-	&& echo 'Include conf/httpd-wordpress.conf' >> $HTTPD_CONF_FILE \
-	## include phpmyadmin.conf
-	&& echo 'Include conf/httpd-phpmyadmin.conf' >> $HTTPD_CONF_FILE
-
-
-# ============================================================
-# Azure Web App on Linux configurations
-# /home is a shared directory among multiple web app instances
-# /home/site/wwwroot for WordPress site
-# /home/phpmyadmin for phpMyAdmin site
-# /home/data for native MariaDB data dir
-# /home/LogFiles/httpd for httpd/php/wordpress/phpmyadmin logs
-# /home/LogFiles/mariadb for mariadb logs
-# ============================================================
-
-ENV WORDPRESS_HOME_AZURE "/home/site/wwwroot"
-ENV PHPMYADMIN_HOME_AZURE "/home/phpmyadmin"
-ENV MARIADB_DATA_DIR_AZURE "/home/data"
-ENV HTTPD_LOG_DIR_AZURE "/home/LogFiles/httpd"
-ENV MARIADB_LOG_DIR_AZURE "/home/LogFiles/mariadb"
-
-RUN set -ex \
+	&& test ! -d /var/lib/php/sessions && mkdir -p /var/lib/php/sessions \
+	&& chown www-data:www-data /var/lib/php/sessions \
+	##
 	&& test ! -d /var/www && mkdir -p /var/www \
-	# wordpress
-	&& rm -rf $WORDPRESS_HOME \
-	&& ln -s $WORDPRESS_HOME_AZURE $WORDPRESS_HOME \
-	# phpmyadmin
-	&& rm -rf $PHPMYADMIN_HOME \
-	&& ln -s $PHPMYADMIN_HOME_AZURE $PHPMYADMIN_HOME \
-	# mariadb
-	&& mkdir -p $MARIADB_DATA_DIR_TEMP \
-	&& cp -R $MARIADB_DATA_DIR/* $MARIADB_DATA_DIR_TEMP/ \
-	&& rm -rf $MARIADB_DATA_DIR \
-	&& ln -s $MARIADB_DATA_DIR_AZURE $MARIADB_DATA_DIR \
-	# httpd, php, wordpress, phpmyadmin logs
-	&& rm -rf $HTTPD_LOG_DIR \
-	&& ln -s $HTTPD_LOG_DIR_AZURE $HTTPD_LOG_DIR \
-	# mariadb log
-	&& rm -rf $MARIADB_LOG_DIR \
-	&& ln -s $MARIADB_LOG_DIR_AZURE $MARIADB_LOG_DIR
+        && echo '<html><head><meta http-equiv="refresh" content="30" /><meta http-equiv="cache-control" content="no-cache" /><title>Installing WordPress</title></head><body>Installing WordPress ... This could be done in minutes. Please refresh your browser later.</body></html>' > /var/www/index.html \
+        && chown -R www-data:www-data /var/www \
+	##
+	&& ln -s $WORDPRESS_HOME /var/www/wordpress \
+	##
+	&& ln -s $PHPMYADMIN_HOME /var/www/phpmyadmin \
+	##
+	&& rm -rf /var/log/mysql \
+	&& ln -s $MARIADB_LOG_DIR /var/log/mysql \
+	##
+	&& rm -rf /var/log/httpd \
+	&& ln -s $HTTPD_LOG_DIR /var/log/httpd
+
 
 # =====
 # final

--- a/Wordpress/Dockerfile
+++ b/Wordpress/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for WordPress
 #
 FROM ubuntu:16.04
-LABEL maintainer "v-jifan@microsoft.com"
+MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
 
 
 # ========
@@ -276,8 +276,8 @@ RUN set -ex \
 	&& chown www-data:www-data /var/lib/php/sessions \
 	##
 	&& test ! -d /var/www && mkdir -p /var/www \
-        && echo '<html><head><meta http-equiv="refresh" content="30" /><meta http-equiv="cache-control" content="no-cache" /><title>Installing WordPress</title></head><body>Installing WordPress ... This could be done in minutes. Please refresh your browser later.</body></html>' > /var/www/index.html \
-        && chown -R www-data:www-data /var/www \
+	&& echo '<html><head><meta http-equiv="refresh" content="30" /><meta http-equiv="pragma" content="no-cache" /><meta http-equiv="cache-control" content="no-cache" /><title>Installing WordPress</title></head><body>Installing WordPress ... This could be done in minutes. Please refresh your browser later.</body></html>' > /var/www/index.html \
+	&& chown -R www-data:www-data /var/www \
 	##
 	&& ln -s $WORDPRESS_HOME /var/www/wordpress \
 	##

--- a/Wordpress/README.md
+++ b/Wordpress/README.md
@@ -5,7 +5,7 @@ A WordPress Docker image which is built with the Dockerfile under this repo can 
 ## Components
 This docker image currently contains the following components:
 
-1. WordPress    **4.7.2**
+1. WordPress    **4.7.3**
 2. PHP          **7.1.2**
 3. Apache HTTPD **2.4.25**
 4. MariaDB      **10.0+**
@@ -29,7 +29,7 @@ You can specify the following environment variables when deploying the image to 
 
 Name | Default Value
 ---- | -------------
-WORDPRESS_DB_HOST | 127.0.0.1
+WORDPRESS_DB_HOST | localhost
 WORDPRESS_DB_NAME | wordpress
 WORDPRESS_DB_USERNAME | wordpress
 WORDPRESS_DB_PASSWORD | MS173m_QN
@@ -49,7 +49,7 @@ At the SETUP page, as shown below, you can change default values of these enviro
 ### Running on Docker engine's host
 The **docker run** command below will get you a container that has a WordPress site connected to the builtin MariaDB, and has the builtin Redis cache server started, and has the builtin phpMyAdmin site enabled.
 ```
-docker run -d -t -p 80:80 fanjeffrey/wordpress:4.7.2
+docker run -d -t -p 80:80 fanjeffrey/wordpress:latest
 ```
 
 The command below will connect the WordPress site within your Docker container to an Azure ClearDb.
@@ -60,20 +60,20 @@ docker run -d -t -p 80:80 \
     -e "WORDPRESS_DB_USERNAME=<your_db_username>" \
     -e "WORDPRESS_DB_PASSWORD=<your_db_password>" \
     -e "WORDPRESS_DB_TABLE_NAME_PREFIX=<your_table_name_prefix>" \
-    fanjeffrey/wordpress:4.7.2
+    fanjeffrey/wordpress:latest
 ```
 
-When you use 127.0.0.1 as the database host, you can customize phpMyAdmin username and password.
+When you use "localhost" as the database host, you can customize phpMyAdmin username and password.
 ```
 docker run -d -t -p 80:80 \
-    -e "WORDPRESS_DB_HOST=127.0.0.1" \
+    -e "WORDPRESS_DB_HOST=localhost" \
     -e "WORDPRESS_DB_NAME=<your_db_name>" \
     -e "WORDPRESS_DB_USERNAME=<your_db_username>" \
     -e "WORDPRESS_DB_PASSWORD=<your_db_password>" \
     -e "WORDPRESS_DB_TABLE_NAME_PREFIX=<your_table_name_prefix>" \
     -e "PHPMYADMIN_USERNAME=<your_phpmyadmin_username>" \
     -e "PHPMYADMIN_PASSWORD=<your_phpmyadmin_password>" \
-    fanjeffrey/wordpress:4.7.2
+    fanjeffrey/wordpress:latest
 ```
 
 ## The Builtin MariaDB server

--- a/Wordpress/azuredeploy.json
+++ b/Wordpress/azuredeploy.json
@@ -29,7 +29,7 @@
         },
         "dockerRegistryImageName": {
             "type": "string",
-            "defaultValue": "fanjeffrey/wordpress:latest"
+            "defaultValue": "appsvc/apps:wordpress"
         },
         "wordPressDatabaseHost": {
             "type": "string",

--- a/Wordpress/azuredeploy.json
+++ b/Wordpress/azuredeploy.json
@@ -29,11 +29,11 @@
         },
         "dockerRegistryImageName": {
             "type": "string",
-            "defaultValue": "fanjeffrey/wordpress:4.7.2"
+            "defaultValue": "fanjeffrey/wordpress:latest"
         },
         "wordPressDatabaseHost": {
             "type": "string",
-            "defaultValue": "127.0.0.1",
+            "defaultValue": "localhost",
             "metadata": {
                 "description": "WordPress Database Host"
             }
@@ -109,7 +109,7 @@
                             "value": "[parameters('wordPressDatabasePassword')]"
                         },
                         {
-                            "name": "WORDPRESS_DB_TABLE_NAME_PREFIX",
+                            "name": "WORDPRESS_DB_PREFIX",
                             "value": "[parameters('wordPressTablePrefix')]"
                         },
                         {

--- a/Wordpress/entrypoint.sh
+++ b/Wordpress/entrypoint.sh
@@ -7,72 +7,164 @@ set_var_if_null(){
 	fi
 }
 
-test ! -d $WORDPRESS_HOME_AZURE && echo "INFO: WordPress site home on Azure: $WORDPRESS_HOME_AZURE not found!"
+setup_httpd_log_dir(){
+	test ! -d "$HTTPD_LOG_DIR" && echo "INFO: $HTTPD_LOG_DIR not found. creating ..." && mkdir -p "$HTTPD_LOG_DIR"
+	chown -R www-data:www-data $HTTPD_LOG_DIR
+}
+
+setup_mariadb_data_dir(){
+	test ! -d "$MARIADB_DATA_DIR" && echo "INFO: $MARIADB_DATA_DIR not found. creating ..." && mkdir -p "$MARIADB_DATA_DIR"
+        
+	# check if 'mysql' database exists
+	if [ ! -d "$MARIADB_DATA_DIR/mysql" ]; then
+                echo "INFO: 'mysql' database doesn't exist under $MARIADB_DATA_DIR. So we think $MARIADB_DATA_DIR is empty."
+                echo "Copying all data files from the original folder /var/lib/mysql to $MARIADB_DATA_DIR ..."
+                cp -R /var/lib/mysql/. $MARIADB_DATA_DIR
+        else
+                echo "INFO: 'mysql' database already exists under $MARIADB_DATA_DIR."
+        fi
+
+	rm -rf /var/lib/mysql
+	ln -s $MARIADB_DATA_DIR /var/lib/mysql
+	
+	chown -R mysql:mysql $MARIADB_DATA_DIR
+}
+
+setup_mariadb_log_dir(){
+	test ! -d "$MARIADB_LOG_DIR" && echo "INFO: $MARIADB_LOG_DIR not found. creating ..." && mkdir -p "$MARIADB_LOG_DIR"
+	chown -R mysql:mysql $MARIADB_LOG_DIR
+}
+
+start_mariadb(){
+	service mysql start
+	rm -f /tmp/mysql.sock
+	ln -s /var/run/mysqld/mysqld.sock /tmp/mysql.sock
+}
+
+setup_phpmyadmin(){
+	test ! -d "$PHPMYADMIN_HOME" && echo "INFO: $PHPMYADMIN_HOME not found. creating ..." && mkdir -p "$PHPMYADMIN_HOME"
+
+	cd $PHPMYADMIN_HOME
+	mv $PHPMYADMIN_SOURCE/phpmyadmin.tar.gz $PHPMYADMIN_HOME/
+	tar -xf phpmyadmin.tar.gz -C $PHPMYADMIN_HOME --strip-components=1
+	# create config.inc.php
+	mv $PHPMYADMIN_SOURCE/phpmyadmin-config.inc.php $PHPMYADMIN_HOME/config.inc.php
+	
+	rm $PHPMYADMIN_HOME/phpmyadmin.tar.gz
+	rm -rf $PHPMYADMIN_SOURCE
+
+	chown -R www-data:www-data $PHPMYADMIN_HOME
+}
+
+load_phpmyadmin(){
+        if ! grep -q "^Include conf/httpd-phpmyadmin.conf" $HTTPD_CONF_FILE; then
+                echo 'Include conf/httpd-phpmyadmin.conf' >> $HTTPD_CONF_FILE
+        fi
+}
+
+setup_wordpress(){
+	test ! -d "$WORDPRESS_HOME" && echo "INFO: $WORDPRESS_HOME not found. creating ..." && mkdir -p "$WORDPRESS_HOME"
+
+	cd $WORDPRESS_HOME
+	mv $WORDPRESS_SOURCE/wordpress.tar.gz $WORDPRESS_HOME/
+	tar -xf wordpress.tar.gz -C $WORDPRESS_HOME/ --strip-components=1
+	# create wp-config.php
+	mv $WORDPRESS_SOURCE/wp-config.php.microsoft $WORDPRESS_HOME/wp-config.php
+
+	rm $WORDPRESS_HOME/wordpress.tar.gz
+	rm -rf $WORDPRESS_SOURCE
+
+	chown -R www-data:www-data $WORDPRESS_HOME 
+}
+
+update_wordpress_config(){
+	set_var_if_null "WORDPRESS_DB_HOST" "localhost"
+	set_var_if_null "WORDPRESS_DB_NAME" "wordpress"
+	set_var_if_null "WORDPRESS_DB_USERNAME" "wordpress"
+	set_var_if_null "WORDPRESS_DB_PASSWORD" "MS173m_QN"
+	set_var_if_null "WORDPRESS_DB_PREFIX" "wp_"
+	if [ "${WORDPRESS_DB_HOST,,}" = "localhost" ]; then
+		export WORDPRESS_DB_HOST="localhost"
+	fi
+
+	# update wp-config.php with the vars
+        sed -i "s/connectstr_dbhost = '';/connectstr_dbhost = '$WORDPRESS_DB_HOST';/" "$WORDPRESS_HOME/wp-config.php"
+        sed -i "s/connectstr_dbname = '';/connectstr_dbname = '$WORDPRESS_DB_NAME';/" "$WORDPRESS_HOME/wp-config.php"
+        sed -i "s/connectstr_dbusername = '';/connectstr_dbusername = '$WORDPRESS_DB_USERNAME';/" "$WORDPRESS_HOME/wp-config.php"
+        sed -i "s/connectstr_dbpassword = '';/connectstr_dbpassword = '$WORDPRESS_DB_PASSWORD';/" "$WORDPRESS_HOME/wp-config.php"
+        sed -i "s/table_prefix  = 'wp_';/table_prefix  = '$WORDPRESS_DB_PREFIX';/" "$WORDPRESS_HOME/wp-config.php"
+}
+
+load_wordpress(){
+        if ! grep -q "^Include conf/httpd-wordpress.conf" $HTTPD_CONF_FILE; then
+                echo 'Include conf/httpd-wordpress.conf' >> $HTTPD_CONF_FILE
+        fi
+}
+
+set -e
+
+echo "INFO: WORDPRESS_DB_HOST:" $WORDPRESS_DB_HOST
+echo "INFO: WORDPRESS_DB_NAME:" $WORDPRESS_DB_NAME
+echo "INFO: WORDPRESS_DB_USERNAME:" $WORDPRESS_DB_USERNAME
+echo "INFO: WORDPRESS_DB_PREFIX:" $WORDPRESS_DB_PREFIX
+echo "INFO: PHPMYADMIN_USERNAME:" $PHPMYADMIN_USERNAME
+
+setup_httpd_log_dir
+apachectl start
 
 # That wp-config.php doesn't exist means WordPress is not installed/configured yet.
-if [ ! -f "$WORDPRESS_HOME/wp-config.php" ]; then
-	# create wp-config.php
-	mv $WORDPRESS_SOURCE/wp-config.php.microsoft $WORDPRESS_SOURCE/wp-config.php
-	# set WordPress vars if they're not declared or unset
-        set_var_if_null "WORDPRESS_DB_HOST" "127.0.0.1"
-        set_var_if_null "WORDPRESS_DB_NAME" "wordpress"
-        set_var_if_null "WORDPRESS_DB_USERNAME" "wordpress"
-        set_var_if_null "WORDPRESS_DB_PASSWORD" "MS173m_QN"
-        set_var_if_null "WORDPRESS_DB_TABLE_NAME_PREFIX" "wp_"
-        # replace {'localhost',,} with '127.0.0.1'
-        if [ "${WORDPRESS_DB_HOST,,}" = "localhost" ]; then
-                export WORDPRESS_DB_HOST="127.0.0.1"
-                echo "Replace localhost with 127.0.0.1 ... $WORDPRESS_DB_HOST"
-        fi
-       	# update wp-config.php with the vars above 
-        sed -i "s/connectstr_dbhost = '';/connectstr_dbhost = '$WORDPRESS_DB_HOST';/" "$WORDPRESS_SOURCE/wp-config.php"
-        sed -i "s/connectstr_dbname = '';/connectstr_dbname = '$WORDPRESS_DB_NAME';/" "$WORDPRESS_SOURCE/wp-config.php"
-        sed -i "s/connectstr_dbusername = '';/connectstr_dbusername = '$WORDPRESS_DB_USERNAME';/" "$WORDPRESS_SOURCE/wp-config.php"
-        sed -i "s/connectstr_dbpassword = '';/connectstr_dbpassword = '$WORDPRESS_DB_PASSWORD';/" "$WORDPRESS_SOURCE/wp-config.php"
-        sed -i "s/table_prefix  = 'wp_';/table_prefix  = '$WORDPRESS_DB_TABLE_NAME_PREFIX';/" "$WORDPRESS_SOURCE/wp-config.php"
-
-	# Because Azure Web App on Linux uses /home/site/wwwroot,
-	# so if /home/site/wwwroot doesn't exist, 
-	# we think the container is not running on Auzre.
-	if [ ! -d "$WORDPRESS_HOME_AZURE" ]; then
-        	rm -rf $WORDPRESS_HOME && mkdir -p $WORDPRESS_HOME
-		rm -rf $PHPMYADMIN_HOME && mkdir -p $PHPMYADMIN_HOME
-		rm -rf $MARIADB_DATA_DIR && mkdir -p $MARIADB_DATA_DIR
-		rm -rf $HTTPD_LOG_DIR && mkdir -p $HTTPD_LOG_DIR
-		rm -rf $MARIADB_LOG_DIR && mkdir -p $MARIADB_LOG_DIR
-	else
-		test ! -d $PHPMYADMIN_HOME_AZURE && mkdir -p $PHPMYADMIN_HOME_AZURE
-		test ! -d $MARIADB_DATA_DIR_AZURE && mkdir -p $MARIADB_DATA_DIR_AZURE
-		test ! -d $HTTPD_LOG_DIR_AZURE && mkdir -p $HTTPD_LOG_DIR_AZURE
-		test ! -d $MARIADB_LOG_DIR_AZURE && mkdir -p $MARIADB_LOG_DIR_AZURE
-	fi
-        cp -R $WORDPRESS_SOURCE/* $WORDPRESS_HOME/ && chown -R www-data:www-data $WORDPRESS_HOME/ && rm -rf $WORDPRESS_SOURCE
-        cp -R $PHPMYADMIN_SOURCE/* $PHPMYADMIN_HOME/ && chown -R www-data:www-data $PHPMYADMIN_HOME/ && rm -rf $PHPMYADMIN_SOURCE
-        cp -R $MARIADB_DATA_DIR_TEMP/* $MARIADB_DATA_DIR/ && chown -R mysql:mysql $MARIADB_DATA_DIR/ && rm -rf $MARIADB_DATA_DIR_TEMP
-	chown -R www-data:www-data $HTTPD_LOG_DIR/
-	chown -R mysql:mysql $MARIADB_LOG_DIR/
-
-	# check if use native MariaDB
-	# if yes, we allow users to use native phpMyAdmin and native Redis server
-	if [ $WORDPRESS_DB_HOST = "127.0.0.1" ]; then
-		# set vars for phpMyAdmin if not provided
-		set_var_if_null 'PHPMYADMIN_USERNAME' 'phpmyadmin'
-		set_var_if_null 'PHPMYADMIN_PASSWORD' 'MS173m_QN'
-		# start native database 
-		service mysql start
-		# create database and databse user for WordPress
-		mysql -u root -e "create database $WORDPRESS_DB_NAME; grant all on $WORDPRESS_DB_NAME.* to '$WORDPRESS_DB_USERNAME'@'127.0.0.1' identified by '$WORDPRESS_DB_PASSWORD'; flush privileges;"
-		# create database user for phpMyAdmin
-		mysql -u root -e "create user '$PHPMYADMIN_USERNAME'@'127.0.0.1' identified by '$PHPMYADMIN_PASSWORD'; grant all on *.* to '$PHPMYADMIN_USERNAME'@'127.0.0.1' with grant option; flush privileges;"	
-		# start native Redis server
-		redis-server --daemonize yes
-	fi
+if [ ! -e "$WORDPRESS_HOME/wp-config.php" ]; then
+	echo "INFO: $WORDPRESS_HOME/wp-config.php not found."
+	echo "Installing WordPress for the first time ..."
+	setup_wordpress
+        update_wordpress_config
 else
-	if grep "connectstr_dbhost = '127.0.0.1'" "$WORDPRESS_HOME/wp-config.php"; then
-		service mysql start
-		redis-server --daemonize yes
+	echo "INFO: $WORDPRESS_HOME/wp-config.php already exists."
+fi	
+
+# If local MariaDB is used in wp-config.php
+if grep -q "^\$connectstr_dbhost = 'localhost'\|^\$connectstr_dbhost = '127.0.0.1'" "$WORDPRESS_HOME/wp-config.php"; then
+	echo "INFO: local MariaDB is used as DB_HOST in wp-config.php."
+	echo "Setting up MariaDB data dir ..."
+	setup_mariadb_data_dir
+	echo "Setting up MariaDB log dir ..."
+	setup_mariadb_log_dir
+	echo "Starting local MariaDB ..."
+	start_mariadb
+	
+	echo "Granting user for phpMyAdmin ..."
+	set_var_if_null 'PHPMYADMIN_USERNAME' 'phpmyadmin'
+	set_var_if_null 'PHPMYADMIN_PASSWORD' 'MS173m_QN'
+	mysql -u root -e "GRANT ALL ON *.* TO \`$PHPMYADMIN_USERNAME\`@'localhost' IDENTIFIED BY '$PHPMYADMIN_PASSWORD' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+	
+	echo "Creating database for WordPress if not exists ..."
+	mysql -u root -e "CREATE DATABASE IF NOT EXISTS \`$WORDPRESS_DB_NAME\` CHARACTER SET utf8 COLLATE utf8_general_ci;"
+	echo "Granting user for WordPress ..."
+	mysql -u root -e "GRANT ALL ON \`$WORDPRESS_DB_NAME\`.* TO \`$WORDPRESS_DB_USERNAME\`@\`$WORDPRESS_DB_HOST\` IDENTIFIED BY '$WORDPRESS_DB_PASSWORD'; FLUSH PRIVILEGES;"
+	
+	echo "Starting local Redis ..."
+	redis-server --daemonize yes
+	
+	if [ ! -e "$PHPMYADMIN_HOME/config.inc.php" ]; then
+	        echo "INFO: $PHPMYADMIN_HOME/config.inc.php not found."
+        	echo "Installing phpMyAdmin ..."
+	        setup_phpmyadmin
+        else
+		echo "INFO: $PHPMYADMIN_HOME/config.inc.php already exists."
 	fi
+	
+	echo "Loading phpMyAdmin conf ..."
+	load_phpmyadmin
+else
+	echo "INFO: local MariaDB is NOT used as DB_HOST in wp-config.php."
 fi
 
-# start Apache HTTPD
-httpd -DFOREGROUND
+apachectl stop
+# delay 2 seconds to try to avoid "httpd (pid XX) already running"
+sleep 2s
+
+echo "Loading WordPress conf ..."
+load_wordpress
+
+echo "Starting Apache httpd -D FOREGROUND ..."
+apachectl start -D FOREGROUND

--- a/Wordpress/httpd-modules.conf
+++ b/Wordpress/httpd-modules.conf
@@ -123,3 +123,4 @@ LoadModule dir_module modules/mod_dir.so
 #LoadModule userdir_module modules/mod_userdir.so
 LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
+

--- a/Wordpress/httpd-php.conf
+++ b/Wordpress/httpd-php.conf
@@ -3,3 +3,4 @@ LoadModule php7_module        modules/libphp7.so
 <FilesMatch \.php$>
     SetHandler application/x-httpd-php
 </FilesMatch>
+

--- a/Wordpress/httpd-phpmyadmin.conf
+++ b/Wordpress/httpd-phpmyadmin.conf
@@ -1,10 +1,10 @@
+
 Alias /phpmyadmin /var/www/phpmyadmin
 
 <Directory /var/www/phpmyadmin>
     Require all granted
     AllowOverride All
-    Options -Indexes
-    
-    DirectoryIndex disabled
-    DirectoryIndex index.php index.html    
+    Options FollowSymlinks
+    DirectoryIndex index.php
 </Directory>
+

--- a/Wordpress/httpd-wordpress.conf
+++ b/Wordpress/httpd-wordpress.conf
@@ -1,15 +1,15 @@
+
 <VirtualHost *:80>
     DocumentRoot /var/www/wordpress
 
     <Directory /var/www/wordpress>
         Require all granted
         AllowOverride All
-        Options -Indexes
-        
-        DirectoryIndex disabled
-        DirectoryIndex index.php index.html
+        Options FollowSymlinks
+        DirectoryIndex index.php
     </Directory>
 
     ErrorLog "/var/log/httpd/wordpress-error_log"
     CustomLog "/var/log/httpd/wordpress-access_log" common
 </VirtualHost>
+

--- a/Wordpress/httpd.conf
+++ b/Wordpress/httpd.conf
@@ -12,6 +12,15 @@ Group www-data
 <Directory />
     Require all denied
     AllowOverride none
+    Options none
+</Directory>
+
+DocumentRoot /var/www
+<Directory /var/www>
+    Require all granted
+    AllowOverride none
+    Options FollowSymlinks
+    DirectoryIndex index.html
 </Directory>
 
 AccessFileName .htaccess    
@@ -25,3 +34,4 @@ ErrorLog "/var/log/httpd/error_log"
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 CustomLog "/var/log/httpd/access_log" common
+

--- a/Wordpress/php-opcache.ini
+++ b/Wordpress/php-opcache.ini
@@ -16,3 +16,4 @@ opcache.memory_consumption=128
 
 ; The maximum number of keys (and therefore scripts) in the OPcache hash table. 
 opcache.max_accelerated_files=4000
+

--- a/Wordpress/php.ini
+++ b/Wordpress/php.ini
@@ -4,3 +4,4 @@ error_log=/var/log/httpd/php-error.log
 display_errors=Off
 display_startup_errors=Off
 date.timezone=UTC
+

--- a/Wordpress/phpmyadmin-config.inc.php
+++ b/Wordpress/phpmyadmin-config.inc.php
@@ -7,9 +7,9 @@ $i = 0;
 $i++;
 
 /* http://stackoverflow.com/questions/1819592/error-when-connecting-to-mysql-using-php-pdo/1819767#1819767 */
-$cfg['Servers'][$i]['host'] = '127.0.0.1';
+$cfg['Servers'][$i]['host'] = 'localhost';
 $cfg['Servers'][$i]['port'] = '';
-$cfg['Servers'][$i]['connect_type'] = 'tcp';
+$cfg['Servers'][$i]['connect_type'] = 'socket';
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 $cfg['Servers'][$i]['AllowRoot'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;


### PR DESCRIPTION
> upgrade wordpress to 4.7.3;
> use /home/site/wwwroot as wordpress site home;
> use /home/data/mysql as mariadb data dir;
> use /home/LogFiles/mysql as mariadb log dir;
> use /home/LogFiles/httpd as httpd/wordpress log dir;
> use /home/phpmyadmin as phpmyadmin site home;
> refactor/rewrite entrypoint.sh to support reloading docker image in another instance;