### PR TITLE
Updated apache version to 2.4.27.

### DIFF
--- a/apache-php-mysql/0.1/Dockerfile
+++ b/apache-php-mysql/0.1/Dockerfile
@@ -1,4 +1,4 @@
-#
+	#
 # Dockerfile for Apache/PHP/MySQL
 #
 FROM ubuntu:16.04
@@ -10,9 +10,9 @@ MAINTAINER Azure App Service Container Images <appsvc-images@microsoft.com>
 # ========
 
 # apache httpd
-ENV HTTPD_VERSION "2.4.25"
+ENV HTTPD_VERSION "2.4.27"
 ENV HTTPD_DOWNLOAD_URL "https://www.apache.org/dist/httpd/httpd-$HTTPD_VERSION.tar.gz"
-ENV HTTPD_SHA1 "377c62dc6b25c9378221111dec87c28f8fe6ac69"
+ENV HTTPD_SHA1 "c0f1b57a70db4843bb1c774b6cc04e169629403c"
 ENV HTTPD_SOURCE "/usr/src/httpd"
 ENV HTTPD_HOME "/usr/local/httpd"
 ENV HTTPD_CONF_DIR "$HTTPD_HOME/conf"


### PR DESCRIPTION
Apache version 2.4.25 is only available in the apache archives now.
So version should be updated in Dockerfile. 

Alternative would be to update the url to point to the archive-version.